### PR TITLE
refactor: split repositories and improve client

### DIFF
--- a/backend/src/main/java/com/example/gymtracker/repository/ExerciseRepository.java
+++ b/backend/src/main/java/com/example/gymtracker/repository/ExerciseRepository.java
@@ -1,0 +1,8 @@
+package com.example.gymtracker.repository;
+
+import com.example.gymtracker.domain.Exercise;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ExerciseRepository extends JpaRepository<Exercise, UUID> {}

--- a/backend/src/main/java/com/example/gymtracker/repository/SessionRepository.java
+++ b/backend/src/main/java/com/example/gymtracker/repository/SessionRepository.java
@@ -1,0 +1,8 @@
+package com.example.gymtracker.repository;
+
+import com.example.gymtracker.domain.Session;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface SessionRepository extends JpaRepository<Session, UUID> {}

--- a/backend/src/main/java/com/example/gymtracker/repository/SetEntryRepository.java
+++ b/backend/src/main/java/com/example/gymtracker/repository/SetEntryRepository.java
@@ -1,11 +1,11 @@
 package com.example.gymtracker.repository;
 
-import com.example.gymtracker.domain.*;
+import com.example.gymtracker.domain.SetEntry;
 import org.springframework.data.jpa.repository.JpaRepository;
-import java.util.*;
 
-public interface ExerciseRepository extends JpaRepository<Exercise, UUID> {}
-public interface SessionRepository extends JpaRepository<Session, UUID> {}
+import java.util.List;
+import java.util.UUID;
+
 public interface SetEntryRepository extends JpaRepository<SetEntry, UUID> {
   List<SetEntry> findBySessionIdOrderBySetIndexAsc(UUID sessionId);
 }

--- a/backend/src/main/java/com/example/gymtracker/web/ExerciseController.java
+++ b/backend/src/main/java/com/example/gymtracker/web/ExerciseController.java
@@ -19,8 +19,8 @@ public class ExerciseController {
   @GetMapping public List<ExerciseDTO> list(){ return service.list(); }
 
   @PostMapping
-  public ResponseEntity<ExerciseDTO> create(@Valid @RequestBody CreateExerciseDTO in){
-    UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+  public ResponseEntity<ExerciseDTO> create(@Valid @RequestBody CreateExerciseDTO in,
+                                           @RequestHeader("X-User-Id") UUID userId){
     return ResponseEntity.status(HttpStatus.CREATED).body(service.create(in, userId));
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,13 +19,14 @@
     "react-router-dom": "^6.26.1",
     "recharts": "^2.12.0"
   },
-  "devDependencies": {
-    "@types/react": "^18.3.3",
-    "@types/react-dom": "^18.3.0",
-    "autoprefixer": "^10.4.19",
-    "postcss": "^8.4.39",
-    "tailwindcss": "^3.4.10",
-    "typescript": "^5.5.4",
-    "vite": "^5.4.1"
+    "devDependencies": {
+      "@types/react": "^18.3.3",
+      "@types/react-dom": "^18.3.0",
+      "@vitejs/plugin-react": "^4.0.0",
+      "autoprefixer": "^10.4.19",
+      "postcss": "^8.4.39",
+      "tailwindcss": "^3.4.10",
+      "typescript": "^5.5.4",
+      "vite": "^5.4.1"
   }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,2 +1,5 @@
 import axios from 'axios';
-export const api = axios.create({ baseURL: 'http://localhost:8080/api' });
+
+export const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL || '/api'
+});

--- a/frontend/src/pages/Exercises.tsx
+++ b/frontend/src/pages/Exercises.tsx
@@ -1,10 +1,11 @@
-import { useQuery, useMutation } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../lib/api";
 import { useState } from "react";
 
 type Exercise = { id: string; name: string; muscleGroup: string };
 
 export default function Exercises(){
+  const queryClient = useQueryClient();
   const { data } = useQuery({
     queryKey: ['exercises'],
     queryFn: async ()=> (await api.get<Exercise[]>('/exercises')).data
@@ -13,7 +14,11 @@ export default function Exercises(){
   const [group, setGroup] = useState("");
   const create = useMutation({
     mutationFn: async ()=> (await api.post('/exercises', { name, muscleGroup: group })).data,
-    onSuccess:()=>window.location.reload()
+    onSuccess:()=>{
+      queryClient.invalidateQueries({ queryKey: ['exercises'] });
+      setName("");
+      setGroup("");
+    }
   });
 
   return (

--- a/frontend/src/pages/Sessions.tsx
+++ b/frontend/src/pages/Sessions.tsx
@@ -5,17 +5,23 @@ export default function Sessions(){
   const [date, setDate] = useState("");
   const [exerciseId, setExerciseId] = useState("");
   const [sessionId, setSessionId] = useState<string|undefined>();
+  const [nextSetIndex, setNextSetIndex] = useState(1);
 
   const createSession = async ()=>{
     const res = await api.post('/sessions', { sessionDate: date });
     setSessionId(res.data.id);
+    setNextSetIndex(1);
   };
 
   const addSet = async ()=>{
     if(!sessionId) return;
     await api.post(`/sessions/${sessionId}/sets`, {
-      exerciseId, setIndex: 1, reps: 10, weightKg: 20.0
+      exerciseId,
+      setIndex: nextSetIndex,
+      reps: 10,
+      weightKg: 20.0
     });
+    setNextSetIndex(nextSetIndex + 1);
     alert('Set added');
   };
 


### PR DESCRIPTION
## Summary
- split repositories into individual files for exercise, session, and set entries
- accept user id from request header when creating exercises
- increment set indices and update exercise list without reloading
- make API base URL configurable and add missing Vite React plugin

## Testing
- `npm --prefix frontend install` (fails: 403 Forbidden fetching @vitejs/plugin-react)
- `npm --prefix frontend run build` (fails: Cannot find package '@vitejs/plugin-react')
- `mvn -q test` (fails: missing dependencies due to unreachable Maven Central)


------
https://chatgpt.com/codex/tasks/task_e_689cdfc12cf083248e5141002b0f2537