### PR TITLE
Fix DTO structure and remove builder usage

### DIFF
--- a/backend/src/main/java/com/example/gymtracker/dto/CreateExerciseDTO.java
+++ b/backend/src/main/java/com/example/gymtracker/dto/CreateExerciseDTO.java
@@ -1,0 +1,5 @@
+package com.example.gymtracker.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateExerciseDTO(@NotBlank String name, @NotBlank String muscleGroup) {}

--- a/backend/src/main/java/com/example/gymtracker/dto/CreateSessionDTO.java
+++ b/backend/src/main/java/com/example/gymtracker/dto/CreateSessionDTO.java
@@ -1,0 +1,9 @@
+package com.example.gymtracker.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record CreateSessionDTO(@NotNull LocalDate sessionDate,
+                               UUID workoutId,
+                               String notes) {}

--- a/backend/src/main/java/com/example/gymtracker/dto/CreateSetDTO.java
+++ b/backend/src/main/java/com/example/gymtracker/dto/CreateSetDTO.java
@@ -1,15 +1,7 @@
 package com.example.gymtracker.dto;
 
 import jakarta.validation.constraints.*;
-import java.time.LocalDate;
 import java.util.UUID;
-
-public record ExerciseDTO(UUID id, String name, String muscleGroup) {}
-public record CreateExerciseDTO(@NotBlank String name, @NotBlank String muscleGroup) {}
-
-public record CreateSessionDTO(@NotNull LocalDate sessionDate,
-                               UUID workoutId,
-                               String notes) {}
 
 public record CreateSetDTO(@NotNull UUID exerciseId,
                            @Min(1) int setIndex,

--- a/backend/src/main/java/com/example/gymtracker/dto/ExerciseDTO.java
+++ b/backend/src/main/java/com/example/gymtracker/dto/ExerciseDTO.java
@@ -1,0 +1,5 @@
+package com.example.gymtracker.dto;
+
+import java.util.UUID;
+
+public record ExerciseDTO(UUID id, String name, String muscleGroup) {}

--- a/backend/src/main/java/com/example/gymtracker/service/ExerciseService.java
+++ b/backend/src/main/java/com/example/gymtracker/service/ExerciseService.java
@@ -18,11 +18,12 @@ public class ExerciseService {
   private final ExerciseMapper mapper;
 
   public ExerciseDTO create(CreateExerciseDTO in, UUID userId){
-    Exercise e = Exercise.builder()
-      .name(in.name())
-      .muscleGroup(in.muscleGroup())
-      .createdBy(userId)
-      .build();
+    Exercise e = new Exercise(
+      null,
+      in.name(),
+      in.muscleGroup(),
+      userId
+    );
     return mapper.toDTO(repo.save(e));
   }
 

--- a/backend/src/main/java/com/example/gymtracker/web/SessionController.java
+++ b/backend/src/main/java/com/example/gymtracker/web/SessionController.java
@@ -24,7 +24,7 @@ public class SessionController {
   public ResponseEntity<Map<String,Object>> get(@PathVariable UUID id){
     return sessions.findById(id)
       .map(s -> {
-        var payload = new HashMap<String,Object>();
+        Map<String,Object> payload = new HashMap<>();
         payload.put("session", s);
         payload.put("sets", sets.findBySessionIdOrderBySetIndexAsc(id));
         return ResponseEntity.ok(payload);
@@ -33,27 +33,29 @@ public class SessionController {
 
   @PostMapping
   public ResponseEntity<Session> create(@Valid @RequestBody CreateSessionDTO in){
-    Session s = Session.builder()
-      .userId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-      .workoutId(in.workoutId())
-      .sessionDate(in.sessionDate())
-      .notes(in.notes())
-      .build();
+    Session s = new Session(
+      null,
+      UUID.fromString("00000000-0000-0000-0000-000000000001"),
+      in.workoutId(),
+      in.sessionDate(),
+      in.notes()
+    );
     return ResponseEntity.status(HttpStatus.CREATED).body(sessions.save(s));
   }
 
   @PostMapping("/{id}/sets")
   public ResponseEntity<SetEntry> addSet(@PathVariable UUID id, @Valid @RequestBody CreateSetDTO in){
     if (!sessions.existsById(id)) return ResponseEntity.notFound().build();
-    SetEntry e = SetEntry.builder()
-      .sessionId(id)
-      .exerciseId(in.exerciseId())
-      .setIndex(in.setIndex())
-      .reps(in.reps())
-      .weightKg(in.weightKg())
-      .rpe(in.rpe())
-      .isPr(Boolean.TRUE.equals(in.isPr()))
-      .build();
+    SetEntry e = new SetEntry(
+      null,
+      id,
+      in.exerciseId(),
+      in.setIndex(),
+      in.reps(),
+      in.weightKg(),
+      in.rpe(),
+      Boolean.TRUE.equals(in.isPr())
+    );
     return ResponseEntity.status(HttpStatus.CREATED).body(sets.save(e));
   }
 }


### PR DESCRIPTION
## Summary
- Split combined DTOs into individual record files
- Replace Lombok builders with explicit constructors
- Fix session lookup response to use a Map payload

## Testing
- `mvn -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e240720e88324962b9c203238ea3d