### PR TITLE
Use BigDecimal for numeric set fields

### DIFF
--- a/backend/src/main/java/com/example/gymtracker/domain/SetEntry.java
+++ b/backend/src/main/java/com/example/gymtracker/domain/SetEntry.java
@@ -2,6 +2,7 @@ package com.example.gymtracker.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import java.math.BigDecimal;
 import java.util.UUID;
 
 @Entity @Table(name = "sets")
@@ -12,8 +13,8 @@ public class SetEntry {
   @Column(name="exercise_id", nullable=false) private UUID exerciseId;
   @Column(name="set_index", nullable=false) private Integer setIndex;
   @Column(nullable=false) private Integer reps;
-  @Column(name="weight_kg", nullable=false) private Double weightKg;
-  private Double rpe;
+  @Column(name="weight_kg", nullable=false, precision = 6, scale = 2) private BigDecimal weightKg;
+  @Column(precision = 3, scale = 1) private BigDecimal rpe;
   @Column(name="is_pr") private Boolean isPr;
   @PrePersist void pre() { if (id == null) id = UUID.randomUUID(); }
 }

--- a/backend/src/main/java/com/example/gymtracker/dto/CreateSetDTO.java
+++ b/backend/src/main/java/com/example/gymtracker/dto/CreateSetDTO.java
@@ -1,11 +1,12 @@
 package com.example.gymtracker.dto;
 
 import jakarta.validation.constraints.*;
+import java.math.BigDecimal;
 import java.util.UUID;
 
 public record CreateSetDTO(@NotNull UUID exerciseId,
                            @Min(1) int setIndex,
                            @Min(1) int reps,
-                           @DecimalMin("0.0") double weightKg,
-                           Double rpe,
+                           @DecimalMin("0.0") BigDecimal weightKg,
+                           BigDecimal rpe,
                            Boolean isPr) {}


### PR DESCRIPTION
## Summary
- Replace Double fields with BigDecimal for SetEntry weights and RPE
- Update set creation DTO to use BigDecimal values

## Testing
- `mvn -q -f backend/pom.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.3.2 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*
- `npm test --prefix frontend` *(fails: Missing script: "test" )*

------
https://chatgpt.com/codex/tasks/task_e_689e7435030883248a437baa224fb5c9