### PR TITLE
feat: add sidebar navigation and workout creation page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,31 @@
-import { Outlet } from "react-router-dom";
-export default function App(){
+import { NavLink, Outlet } from "react-router-dom";
+
+export default function App() {
+  const linkClass = ({ isActive }: { isActive: boolean }) =>
+    `block px-3 py-2 rounded hover:bg-gray-100 ${isActive ? "bg-gray-200 font-medium" : ""}`;
+
   return (
     <div className="min-h-screen flex">
-      <aside className="w-60 border-r p-4">GymTracker</aside>
-      <main className="flex-1 p-6"><Outlet /></main>
+      <aside className="w-60 border-r p-4 space-y-4">
+        <h1 className="text-xl font-semibold">GymTracker</h1>
+        <nav className="space-y-1">
+          <NavLink to="/" end className={linkClass}>
+            Dashboard
+          </NavLink>
+          <NavLink to="/workouts" className={linkClass}>
+            Workouts
+          </NavLink>
+          <NavLink to="/exercises" className={linkClass}>
+            Exercises
+          </NavLink>
+          <NavLink to="/sessions" className={linkClass}>
+            Sessions
+          </NavLink>
+        </nav>
+      </aside>
+      <main className="flex-1 p-6">
+        <Outlet />
+      </main>
     </div>
   );
 }

--- a/frontend/src/pages/Workouts.tsx
+++ b/frontend/src/pages/Workouts.tsx
@@ -1,1 +1,93 @@
-export default function Workouts(){ return <div>Workouts (em breve)</div>; }
+import { useState } from "react";
+
+type ExerciseEntry = {
+  name: string;
+  weight: string;
+  reps: string;
+};
+
+export default function Workouts() {
+  const [exercise, setExercise] = useState("");
+  const [weight, setWeight] = useState("");
+  const [reps, setReps] = useState("");
+  const [list, setList] = useState<ExerciseEntry[]>([]);
+
+  const addExercise = () => {
+    if (!exercise || !weight || !reps) return;
+    setList([...list, { name: exercise, weight, reps }]);
+    setExercise("");
+    setWeight("");
+    setReps("");
+  };
+
+  const saveWorkout = () => {
+    console.log(list);
+    alert("Workout saved");
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold">New Workout</h1>
+      <div className="flex gap-2">
+        <input
+          className="border rounded px-3 py-2 flex-1"
+          placeholder="Exercise"
+          value={exercise}
+          onChange={(e) => setExercise(e.target.value)}
+        />
+        <input
+          className="border rounded px-3 py-2 w-24"
+          type="number"
+          placeholder="Weight (kg)"
+          value={weight}
+          onChange={(e) => setWeight(e.target.value)}
+        />
+        <input
+          className="border rounded px-3 py-2 w-24"
+          type="number"
+          placeholder="Reps"
+          value={reps}
+          onChange={(e) => setReps(e.target.value)}
+        />
+        <button
+          className="px-4 py-2 rounded bg-black text-white"
+          onClick={addExercise}
+        >
+          Add
+        </button>
+      </div>
+
+      {list.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-left border">
+            <thead>
+              <tr className="bg-gray-100">
+                <th className="px-3 py-2 border-r">Exercise</th>
+                <th className="px-3 py-2 border-r">Weight (kg)</th>
+                <th className="px-3 py-2">Reps</th>
+              </tr>
+            </thead>
+            <tbody>
+              {list.map((item, idx) => (
+                <tr key={idx} className="border-t">
+                  <td className="px-3 py-2 border-r">{item.name}</td>
+                  <td className="px-3 py-2 border-r">{item.weight}</td>
+                  <td className="px-3 py-2">{item.reps}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <button
+        className="px-4 py-2 rounded bg-black text-white"
+        onClick={saveWorkout}
+        disabled={list.length === 0}
+      >
+        Save Workout
+      </button>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add sidebar navigation with links to main pages
- implement workout creation page with exercise, weight and reps list

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e884f06f48324bd5ba25b824595ab